### PR TITLE
feat: implement LIC 3 with geometry helpers and type cleanup

### DIFF
--- a/assignment1/src/launch_interceptor_program/decide.py
+++ b/assignment1/src/launch_interceptor_program/decide.py
@@ -11,9 +11,9 @@ def decide(inputs: DecisionInput) -> DecisionResult:
     input rader tracking information.
 
     Args:
-        inputs: DecisionInput(points, parameters, lcm, puv)
+        inputs: DecisionInput(POINTS, PARAMETERS, LCM, PUV)
 
     Returns:
-        DecisionResult(launch, cmv, pum, fuv)
+        DecisionResult(LAUNCH, CMV, PUM, FUV)
     """
     raise NotImplementedError("DECIDE logic not implemented yet")

--- a/assignment1/src/launch_interceptor_program/lic/__init__.py
+++ b/assignment1/src/launch_interceptor_program/lic/__init__.py
@@ -1,0 +1,1 @@
+from .lic_3 import lic_3

--- a/assignment1/src/launch_interceptor_program/lic/geometry.py
+++ b/assignment1/src/launch_interceptor_program/lic/geometry.py
@@ -1,0 +1,25 @@
+"""
+Geometric helper functions for LIC evaluations.
+
+Provides common calculations including areas, distances, etc.
+"""
+
+from ..model import Point
+
+def triangle_area(p1: Point, p2: Point, p3: Point) -> float:
+    """
+    Calculate the area of a triangle formed by three points.
+
+    Uses the shoelace formula: 0.5 * |x1(y2 - y3) + x2(y3 - y1) + x3(y1 - y2)|
+    
+    Returns 0.0 for collinear points.
+    """
+    # unpack coordinates from points
+    x1, y1 = p1
+    x2, y2 = p2
+    x3, y3 = p3
+
+    # apply shoelace formula
+    area = 0.5 * abs(x1 * (y2 - y3) + x2 * (y3 - y1) + x3 * (y1 - y2))
+
+    return area

--- a/assignment1/src/launch_interceptor_program/lic/lic_3.py
+++ b/assignment1/src/launch_interceptor_program/lic/lic_3.py
@@ -1,0 +1,10 @@
+from ..model import Parameters, Points
+from .geometry import triangle_area
+
+def lic_3(points: Points, parameters: Parameters) -> bool:
+    for i in range(len(points) - 2):
+        area = triangle_area(points[i], points[i + 1], points[i + 2])
+        if area > parameters.AREA1:
+            return True
+    
+    return False

--- a/assignment1/src/launch_interceptor_program/model.py
+++ b/assignment1/src/launch_interceptor_program/model.py
@@ -6,10 +6,6 @@ These types model the DECIDE() inputs and outputs defined in the spec.
 
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import List, Sequence, Tuple
-
-
-Point = Tuple[float, float]
 
 
 class Connector(IntEnum):
@@ -41,20 +37,22 @@ class Parameters:
     RADIUS2: float
     AREA2: float
 
+Point = tuple[float, float]
+Points = list[Point]
 
 @dataclass(frozen=True)
 class DecisionInput:
     """Grouped inputs for a DECIDE() evaluation."""
-    points: Sequence[Point]
-    parameters: Parameters
-    lcm: Sequence[Sequence[Connector]]
-    puv: Sequence[bool]
+    POINTS: Points
+    PARAMETERS: Parameters
+    LCM: list[list[Connector]]
+    PUV: list[bool]
 
 
 @dataclass(frozen=True)
 class DecisionResult:
     """DECIDE() output and intermediate vectors."""
-    launch: bool
-    cmv: List[bool]
-    pum: List[List[bool]]
-    fuv: List[bool]
+    LAUNCH: bool
+    CMV: list[bool]
+    PUM: list[list[bool]]
+    FUV: list[bool]

--- a/assignment1/tests/test_geometry.py
+++ b/assignment1/tests/test_geometry.py
@@ -1,0 +1,17 @@
+from launch_interceptor_program.lic.geometry import triangle_area
+
+
+def test_triangle_area_unit_triangle():
+    """Unit right triangle should have area 0.5"""
+    result = triangle_area((0, 0), (1, 0), (0, 1))
+    assert result == 0.5
+
+def test_triangle_area_collinear_points():
+    """Collinear points should have area 0"""
+    result = triangle_area((0, 0), (1, 1), (2, 2))
+    assert result == 0.0
+
+def test_triangle_area_known_triangle():
+    """Triangle with base 2, height 3 should have area 3"""
+    result = triangle_area((0, 0), (2, 0), (0, 3))
+    assert result == 3.0


### PR DESCRIPTION
There were a bit of changes:

- Ensuring less imports by simplifying the typing in model.py
- Implement LIC 3 which will serve as a good example of structure for other LIC implementations
- Three unit tests for triangle_area helper which is found in geometry.py

Overall it is a bit bundled together but I would say it makes it easier work from the example and just have some typing
abstractions.