### PR TITLE
docs: add minimum docker version requirement closes #82

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The main mechanism of the LIC is the DECIDE()-function, which will output a laun
 ## Requirements
 
 - Python 3.10+
+- Docker 20.10.0+ (Industry standard minimum recommendation)
 
 ## Run program
 


### PR DESCRIPTION
updated the requirements section in README.md to specify docker 20.10.0 as a minimum version